### PR TITLE
Added missing escape in google url allow pattern

### DIFF
--- a/cmd/ssokenizer/main.go
+++ b/cmd/ssokenizer/main.go
@@ -206,7 +206,7 @@ func (c IdentityProviderConfig) providerConfig(name, returnURL string) (ssokeniz
 	case "google":
 		return &oauth2.Config{
 			Path:               "/" + name,
-			AllowedHostPattern: `.*\.googleapis.com`,
+			AllowedHostPattern: `.*\.googleapis\.com`,
 			Config: xoauth2.Config{
 				ClientID:     c.ClientID,
 				ClientSecret: c.ClientSecret,


### PR DESCRIPTION
I can't immediately see how this would be exploitable, but better to be strict?