### PR TITLE
Allow different tokenizer auth for different providers

### DIFF
--- a/cmd/ssokenizer/main.go
+++ b/cmd/ssokenizer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/superfly/ssokenizer"
 	"github.com/superfly/ssokenizer/oauth2"
+	"github.com/superfly/tokenizer"
 	xoauth2 "golang.org/x/oauth2"
 	"golang.org/x/oauth2/amazon"
 	"golang.org/x/oauth2/bitbucket"
@@ -68,16 +70,43 @@ type Config struct {
 	// Tokenizer seal (public) key
 	SealKey string `yaml:"seal_key"`
 
-	// Auth key to put on tokenizer secrets
-	ProxyAuthorization string `yaml:"proxy_authorization"`
-
 	// Where to return user after auth dance. If present, the string `:name` is
 	// replaced with the provider name. Can also be specified per-provider.
 	ReturnURL string `yaml:"return_url"`
 
+	SecretAuth        SecretAuthConfig                  `yaml:"secret_auth"`
 	Log               LogConfig                         `yaml:"log"`
 	HTTP              HTTPConfig                        `yaml:"http"`
 	IdentityProviders map[string]IdentityProviderConfig `yaml:"identity_providers"`
+}
+
+// Specifies what authentication clients should be required to present to
+// tokenizer in order to use sealed secrets.
+type SecretAuthConfig struct {
+	// The plain string that clients must pass in the Proxy-Authorization
+	// header.
+	Bearer string `yaml:"bearer"`
+
+	// Hex SHA256 digest of string that clients must pass in the
+	// Proxy-Authorization header.
+	BearerDigest string `yaml:"bearer_digest"`
+}
+
+func (c SecretAuthConfig) tokenizerAuthConfig() (tokenizer.AuthConfig, error) {
+	switch {
+	case c.Bearer != "" && c.BearerDigest != "":
+		return nil, errors.New("bearer and bearer_digest are mutually exclusive")
+	case c.Bearer != "":
+		return tokenizer.NewBearerAuthConfig(c.Bearer), nil
+	case c.BearerDigest != "":
+		d, err := hex.DecodeString(c.BearerDigest)
+		if err != nil {
+			return nil, err
+		}
+		return &tokenizer.BearerAuthConfig{Digest: d}, nil
+	default:
+		return nil, nil
+	}
 }
 
 // NewConfig returns a new instance of Config with defaults set.
@@ -88,6 +117,11 @@ func NewConfig() Config {
 
 // Validate returns an error if the config is invalid.
 func (c *Config) Validate() error {
+	tac, err := c.SecretAuth.tokenizerAuthConfig()
+	if err != nil {
+		return err
+	}
+
 	if c.SealKey == "" {
 		return errors.New("missing seal_key")
 	}
@@ -95,7 +129,7 @@ func (c *Config) Validate() error {
 		return errors.New("missing http.address")
 	}
 	for _, pc := range c.IdentityProviders {
-		if err := pc.Validate(c.ReturnURL == "", c.ProxyAuthorization == ""); err != nil {
+		if err := pc.Validate(c.ReturnURL == "", tac == nil); err != nil {
 			return err
 		}
 	}
@@ -133,8 +167,7 @@ type IdentityProviderConfig struct {
 	// oauth token endpoint URL. Only needed for "oauth" profile
 	TokenURL string `yaml:"token_url"`
 
-	// Auth key to put on tokenizer secrets
-	ProxyAuthorization string `yaml:"proxy_authorization"`
+	SecretAuth SecretAuthConfig `yaml:"secret_auth"`
 }
 
 func (c IdentityProviderConfig) providerConfig(name, returnURL string) (ssokenizer.ProviderConfig, error) {
@@ -257,8 +290,12 @@ func (c IdentityProviderConfig) Validate(needsReturnURL, needsProxyAuthorization
 	if c.ReturnURL == "" && needsReturnURL {
 		return errors.New("missing return_url or identity_providers.return_url")
 	}
-	if c.ProxyAuthorization == "" && needsProxyAuthorization {
-		return errors.New("missing proxy_authorization or identity_providers.proxy_authorization")
+
+	switch tac, err := c.SecretAuth.tokenizerAuthConfig(); {
+	case err != nil:
+		return err
+	case tac == nil && needsProxyAuthorization:
+		return errors.New("missing secret_auth or identity_providers.secret_auth")
 	}
 
 	return nil

--- a/context.go
+++ b/context.go
@@ -9,16 +9,21 @@ type contextKey string
 
 const (
 	contextKeyTransaction contextKey = "transaction"
+	contextKeyProvider    contextKey = "provider"
 )
 
-func withTransaction(ctx context.Context, t *Transaction) context.Context {
-	return context.WithValue(ctx, contextKeyTransaction, t)
+func withTransaction(r *http.Request, t *Transaction) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), contextKeyTransaction, t))
 }
 
 func GetTransaction(r *http.Request) *Transaction {
-	return transactionFromContext(r.Context())
+	return r.Context().Value(contextKeyTransaction).(*Transaction)
 }
 
-func transactionFromContext(ctx context.Context) *Transaction {
-	return ctx.Value(contextKeyTransaction).(*Transaction)
+func withProvider(r *http.Request, p *provider) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), contextKeyProvider, p))
+}
+
+func getProvider(r *http.Request) *provider {
+	return r.Context().Value(contextKeyProvider).(*provider)
 }

--- a/context.go
+++ b/context.go
@@ -15,13 +15,10 @@ func withTransaction(ctx context.Context, t *Transaction) context.Context {
 	return context.WithValue(ctx, contextKeyTransaction, t)
 }
 
-func GetTransaction(r *http.Request) (*Transaction, bool) {
+func GetTransaction(r *http.Request) *Transaction {
 	return transactionFromContext(r.Context())
 }
 
-func transactionFromContext(ctx context.Context) (*Transaction, bool) {
-	if t, ok := ctx.Value(contextKeyTransaction).(*Transaction); ok {
-		return t, true
-	}
-	return nil, false
+func transactionFromContext(ctx context.Context) *Transaction {
+	return ctx.Value(contextKeyTransaction).(*Transaction)
 }

--- a/etc/ssokenizer.yml
+++ b/etc/ssokenizer.yml
@@ -1,10 +1,6 @@
 # Public part of tokenizer's keypair
 seal_key: "$TOKENIZER_SEAL_KEY"
 
-# Apps using sealed secrets with tokenizer will put this token in the
-# `Proxy-Authorization` header.
-proxy_authorization: "$PROXY_AUTH"
-
 http:
   # Where ssokenizer should listen
   address: ":$PORT"
@@ -20,6 +16,11 @@ identity_providers:
   # `google` here is the provider name. Users will go to
   # https://<ssokenizer_url>/<provider_name>/start to start the oauth dance
   google:
+    # Apps using sealed secrets with tokenizer will put this token in the
+    # `Proxy-Authorization` header.
+    secret_auth:
+      bearer: "$PROXY_AUTH"
+
     # amazon, bitbucket, facebook, github, gitlab, google, heroku, microsoft,
     # slack, or oauth.
     profile: google
@@ -46,6 +47,8 @@ identity_providers:
     # token_url: $PROVIDER_TOKEN_URL
 
   github:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: github
     client_id: "$GITHUB_CLIENT_ID"
     client_secret: "$GITHUB_CLIENT_SECRET"
@@ -54,6 +57,8 @@ identity_providers:
       - "$GITHUB_SCOPES"
 
   heroku:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: heroku
     client_id: "$HEROKU_CLIENT_ID"
     client_secret: "$HEROKU_CLIENT_SECRET"
@@ -64,6 +69,8 @@ identity_providers:
   # Same configurations except for name and return_url to allow authentication
   # to staging environments with same OAuth client.
   google_staging:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: google
     client_id: "$GOOGLE_CLIENT_ID"
     client_secret: "$GOOGLE_CLIENT_SECRET"
@@ -72,6 +79,8 @@ identity_providers:
       - "$GOOGLE_SCOPES"
 
   google_staging_2:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: google
     client_id: "$GOOGLE_CLIENT_ID"
     client_secret: "$GOOGLE_CLIENT_SECRET"
@@ -80,6 +89,8 @@ identity_providers:
       - "$GOOGLE_SCOPES"
 
   github_staging:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: github
     client_id: "$GITHUB_CLIENT_ID"
     client_secret: "$GITHUB_CLIENT_SECRET"
@@ -88,6 +99,8 @@ identity_providers:
       - "$GITHUB_SCOPES"
 
   github_staging_2:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: github
     client_id: "$GITHUB_CLIENT_ID"
     client_secret: "$GITHUB_CLIENT_SECRET"
@@ -96,6 +109,8 @@ identity_providers:
       - "$GITHUB_SCOPES"
 
   heroku_staging:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: heroku
     client_id: "$HEROKU_CLIENT_ID"
     client_secret: "$HEROKU_CLIENT_SECRET"
@@ -104,6 +119,8 @@ identity_providers:
       - "$HEROKU_SCOPES"
 
   heroku_staging_2:
+    secret_auth:
+      bearer: "$PROXY_AUTH"
     profile: heroku
     client_id: "$HEROKU_CLIENT_ID"
     client_secret: "$HEROKU_CLIENT_SECRET"

--- a/fly.toml
+++ b/fly.toml
@@ -9,9 +9,8 @@ processes = []
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = true
-  auto_start_machines = true
-  min_machines_running = 1
+  auto_stop_machines = false
+  auto_start_machines = false
 
 [http_service.concurrency]
   type = "requests"

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -29,6 +29,7 @@ type Config struct {
 
 var _ ssokenizer.ProviderConfig = Config{}
 
+// implements ssokenizer.ProviderConfig
 func (c Config) Register(sealKey string, rpAuth string) (http.Handler, error) {
 	switch {
 	case c.ClientID == "":
@@ -72,24 +73,12 @@ func (p *provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *provider) handleStart(w http.ResponseWriter, r *http.Request) {
-	tr, ok := ssokenizer.GetTransaction(r)
-	if !ok {
-		logrus.Warn("no transaction for request")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
+	tr := ssokenizer.GetTransaction(r)
 	http.Redirect(w, r, p.config(r).AuthCodeURL(tr.Nonce, oauth2.AccessTypeOffline), http.StatusFound)
 }
 
 func (p *provider) handleCallback(w http.ResponseWriter, r *http.Request) {
-	tr, ok := ssokenizer.GetTransaction(r)
-	if !ok {
-		logrus.Warn("no transaction for request")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
+	tr := ssokenizer.GetTransaction(r)
 	params := r.URL.Query()
 
 	if errParam := params.Get("error"); errParam != "" {

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -30,7 +30,7 @@ type Config struct {
 var _ ssokenizer.ProviderConfig = Config{}
 
 // implements ssokenizer.ProviderConfig
-func (c Config) Register(sealKey string, rpAuth string) (http.Handler, error) {
+func (c Config) Register(sealKey string, auth tokenizer.AuthConfig) (http.Handler, error) {
 	switch {
 	case c.ClientID == "":
 		return nil, errors.New("missing client_id")
@@ -40,7 +40,7 @@ func (c Config) Register(sealKey string, rpAuth string) (http.Handler, error) {
 
 	return &provider{
 		sealKey:                  sealKey,
-		rpAuth:                   rpAuth,
+		auth:                     auth,
 		AllowedHostPattern:       c.AllowedHostPattern,
 		configWithoutRedirectURL: c,
 	}, nil
@@ -48,7 +48,7 @@ func (c Config) Register(sealKey string, rpAuth string) (http.Handler, error) {
 
 type provider struct {
 	sealKey                  string
-	rpAuth                   string
+	auth                     tokenizer.AuthConfig
 	AllowedHostPattern       string
 	configWithoutRedirectURL Config
 }
@@ -120,7 +120,7 @@ func (p *provider) handleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	secret := &tokenizer.Secret{
-		AuthConfig: tokenizer.NewBearerAuthConfig(p.rpAuth),
+		AuthConfig: p.auth,
 		ProcessorConfig: &tokenizer.OAuthProcessorConfig{
 			Token: &tokenizer.OAuthToken{
 				AccessToken:  tok.AccessToken,
@@ -163,7 +163,7 @@ func (p *provider) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	secret := &tokenizer.Secret{
-		AuthConfig: tokenizer.NewBearerAuthConfig(p.rpAuth),
+		AuthConfig: p.auth,
 		ProcessorConfig: &tokenizer.OAuthProcessorConfig{
 			Token: &tokenizer.OAuthToken{
 				AccessToken:  tok.AccessToken,

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -48,7 +48,7 @@ func TestOauth2(t *testing.T) {
 	tkzServer := httptest.NewServer(tkz)
 	t.Cleanup(tkzServer.Close)
 
-	skz := ssokenizer.NewServer(sealKey, rpAuth)
+	skz := ssokenizer.NewServer(sealKey)
 	assert.NoError(t, skz.Start("127.0.0.1:"))
 	t.Logf("skz=http://%s", skz.Address)
 	t.Cleanup(func() {
@@ -68,7 +68,7 @@ func TestOauth2(t *testing.T) {
 			},
 			Scopes: []string{"my scope"},
 		},
-	}, rpServer.URL))
+	}, rpServer.URL, tokenizer.NewBearerAuthConfig(rpAuth)))
 
 	client := new(http.Client)
 	client.Jar, _ = cookiejar.New(nil)

--- a/provider.go
+++ b/provider.go
@@ -3,9 +3,12 @@ package ssokenizer
 import (
 	"net/http"
 	"net/url"
+
+	"github.com/superfly/tokenizer"
 )
 
 type provider struct {
+	name      string
 	handler   http.Handler
 	returnURL *url.URL
 }
@@ -16,5 +19,5 @@ type ProviderConfig interface {
 	// for requests to the provider. The provider can call GetTransaction to
 	// receive user state from the in-progress SSO transaction. The Transaction
 	// can be used to return data or error messages to the relying party.
-	Register(sealKey string, rpAuth string) (http.Handler, error)
+	Register(sealKey string, auth tokenizer.AuthConfig) (http.Handler, error)
 }

--- a/provider.go
+++ b/provider.go
@@ -10,6 +10,11 @@ type provider struct {
 	returnURL *url.URL
 }
 
+// Arbitrary configuration type for providers to implement.
 type ProviderConfig interface {
+	// Register should validate the provider configuration and return a handler
+	// for requests to the provider. The provider can call GetTransaction to
+	// receive user state from the in-progress SSO transaction. The Transaction
+	// can be used to return data or error messages to the relying party.
 	Register(sealKey string, rpAuth string) (http.Handler, error)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -16,18 +16,36 @@ const (
 	transactionTTL        = time.Hour
 )
 
+// State about the user's SSO attempt that is stored as a cookie. Cookies are
+// set with per-provider paths to prevent transactions from different providers
+// from interfering with each other.
 type Transaction struct {
+	// Random state string that will be returned in our redirect to the relying
+	//  party. This is used to prevent login-CSRF attacks.
 	ReturnState string
-	Nonce       string
-	Expiry      time.Time
-	returnURL   *url.URL
-	cookiePath  string
+
+	// Random string that provider implementations can use as the state
+	// parameter for downstream SSO flows.
+	Nonce string
+
+	// Time after which this transaction cookie will be ignored.
+	Expiry time.Time
+
+	// Where the user should be returned at the completion of the transaction.
+	returnURL *url.URL
+
+	// The path that the transaction cookie should be set on.
+	cookiePath string
 }
 
+// Return the user to the returnURL with the provided data set as query string
+// parameters.
 func (t *Transaction) ReturnData(w http.ResponseWriter, r *http.Request, data map[string]string) {
 	t.returnData(w, r, data)
 }
 
+// Return the user to the returnURL with the provided msg set in the `error`
+// query string parameter.
 func (t *Transaction) ReturnError(w http.ResponseWriter, r *http.Request, msg string) {
 	t.returnData(w, r, map[string]string{"error": msg})
 }


### PR DESCRIPTION
This allows ssokenizer to be used from multiple services without them having to share the tokenizer auth secret. 