### PR TITLE
avoid re-using stale state in parallel auth flows

### DIFF
--- a/context.go
+++ b/context.go
@@ -10,18 +10,9 @@ import (
 type contextKey string
 
 const (
-	contextKeyTransaction contextKey = "transaction"
-	contextKeyProvider    contextKey = "provider"
-	contextKeyLog         contextKey = "log"
+	contextKeyProvider contextKey = "provider"
+	contextKeyLog      contextKey = "log"
 )
-
-func withTransaction(r *http.Request, t *Transaction) *http.Request {
-	return r.WithContext(context.WithValue(r.Context(), contextKeyTransaction, t))
-}
-
-func GetTransaction(r *http.Request) *Transaction {
-	return r.Context().Value(contextKeyTransaction).(*Transaction)
-}
 
 func withProvider(r *http.Request, p *provider) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), contextKeyProvider, p))

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -77,7 +77,10 @@ func (p *provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (p *provider) handleStart(w http.ResponseWriter, r *http.Request) {
 	defer getLog(r).WithField("status", http.StatusFound).Info()
 
-	tr := ssokenizer.GetTransaction(r)
+	tr := ssokenizer.StartTransaction(w, r)
+	if tr == nil {
+		return
+	}
 
 	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
 
@@ -89,7 +92,10 @@ func (p *provider) handleStart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *provider) handleCallback(w http.ResponseWriter, r *http.Request) {
-	tr := ssokenizer.GetTransaction(r)
+	tr := ssokenizer.RestoreTransaction(w, r)
+	if tr == nil {
+		return
+	}
 	params := r.URL.Query()
 
 	if errParam := params.Get("error"); errParam != "" {


### PR DESCRIPTION
Separates transaction creation and resumption into explicitly separate functions that are called explicitly from the appropriate request handler in the provider, rather than create/resume being called in order in the base handler itself.

There are no use-cases where both creation and resumption are expected to occur in a single request, so the previous implementation is bug-prone.

Fixes: #9