### PR TITLE
Allow `source_id` to be configured for vanta provider

### DIFF
--- a/cmd/ssokenizer/main.go
+++ b/cmd/ssokenizer/main.go
@@ -226,6 +226,10 @@ type IdentityProviderConfig struct {
 	MusicKitDeveloperToken string `yaml:"developer_token"`
 
 	SecretAuth SecretAuthConfig `yaml:"secret_auth"`
+
+	// source_id parameter to pass to Vanta provider. Only needed for "vanta" profile
+	// TODO: figure out a way to pass a map[string]string of "extra" stuff to providers.
+	SourceID string `yaml:"source_id"`
 }
 
 func (ic *IdentityProviderConfig) provider(name string, c *Config) (ssokenizer.Provider, error) {
@@ -303,13 +307,18 @@ func (ic *IdentityProviderConfig) oauthProvider(pc ssokenizer.ProviderConfig, c 
 
 	switch ic.Profile {
 	case "vanta":
+		if ic.SourceID == "" {
+			return nil, errors.New("missing source_id")
+		}
+
 		op.OAuthConfig.Endpoint = xoauth2.Endpoint{
 			AuthURL:   "https://app.vanta.com/oauth/authorize",
 			TokenURL:  "https://api.vanta.com/oauth/token",
 			AuthStyle: xoauth2.AuthStyleInParams,
 		}
 
-		op.ForwardParams = []string{"source_id"}
+		op.AuthRequestParams = map[string]string{"source_id": ic.SourceID}
+		op.TokenRequestParams = map[string]string{"source_id": ic.SourceID}
 
 		return &vanta.Provider{Provider: op}, nil
 	case "oauth":

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -24,6 +24,12 @@ type Provider struct {
 	// ForwardParams are the parameters that should be forwarded from the start
 	// request to the auth URL.
 	ForwardParams []string
+
+	// Params to add to the auth request.
+	AuthRequestParams map[string]string
+
+	// Params to add to the token request.
+	TokenRequestParams map[string]string
 }
 
 var _ ssokenizer.Provider = (*Provider)(nil)
@@ -86,6 +92,10 @@ func (p *Provider) handleStart(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	for key, value := range p.AuthRequestParams {
+		opts = append(opts, oauth2.SetAuthURLParam(key, value))
+	}
+
 	if p.OAuthConfig.RedirectURL == "" {
 		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", p.URL.JoinPath(callbackPath).String()))
 	}
@@ -129,6 +139,11 @@ func (p *Provider) handleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+
+	for key, value := range p.TokenRequestParams {
+		opts = append(opts, oauth2.SetAuthURLParam(key, value))
+	}
+
 	if p.OAuthConfig.RedirectURL == "" {
 		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", p.URL.JoinPath(callbackPath).String()))
 	}

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -143,6 +143,9 @@ func (p *Provider) handleCallback(w http.ResponseWriter, r *http.Request) {
 	for key, value := range p.TokenRequestParams {
 		opts = append(opts, oauth2.SetAuthURLParam(key, value))
 	}
+	if p.OAuthConfig.RedirectURL == "" {
+		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", p.URL.JoinPath(callbackPath).String()))
+	}
 
 	if p.OAuthConfig.RedirectURL == "" {
 		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", p.URL.JoinPath(callbackPath).String()))

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -143,9 +143,6 @@ func (p *Provider) handleCallback(w http.ResponseWriter, r *http.Request) {
 	for key, value := range p.TokenRequestParams {
 		opts = append(opts, oauth2.SetAuthURLParam(key, value))
 	}
-	if p.OAuthConfig.RedirectURL == "" {
-		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", p.URL.JoinPath(callbackPath).String()))
-	}
 
 	if p.OAuthConfig.RedirectURL == "" {
 		opts = append(opts, oauth2.SetAuthURLParam("redirect_uri", p.URL.JoinPath(callbackPath).String()))


### PR DESCRIPTION
This parameter gets included on the auth/token requests.