### PR TITLE
Surface classified OAuth2 errors on token refresh

### DIFF
--- a/oauth2/errors.go
+++ b/oauth2/errors.go
@@ -1,0 +1,39 @@
+package oauth2
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// writeOAuth2Error writes an RFC 6749 §5.2 error response: a JSON body
+// when err unwraps to a *oauth2.RetrieveError with a non-empty ErrorCode,
+// empty body otherwise. RFC §5.1 cache-prevention headers are set on
+// every response. Logging is the caller's responsibility.
+func writeOAuth2Error(w http.ResponseWriter, status int, err error) {
+	h := w.Header()
+	h.Set("Cache-Control", "no-store")
+	h.Set("Pragma", "no-cache")
+
+	var re *oauth2.RetrieveError
+	if !errors.As(err, &re) || re.ErrorCode == "" {
+		w.WriteHeader(status)
+		return
+	}
+
+	body, _ := json.Marshal(struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description,omitempty"`
+		ErrorURI         string `json:"error_uri,omitempty"`
+	}{
+		Error:            re.ErrorCode,
+		ErrorDescription: re.ErrorDescription,
+		ErrorURI:         re.ErrorURI,
+	})
+
+	h.Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}

--- a/oauth2/errors_test.go
+++ b/oauth2/errors_test.go
@@ -1,0 +1,112 @@
+package oauth2
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"golang.org/x/oauth2"
+)
+
+func TestWriteOAuth2Error(t *testing.T) {
+	type want struct {
+		status      int
+		body        string
+		contentType string // "" => header MUST be absent
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want want
+	}{
+		// full RFC §5.2 fields pass through
+		{
+			name: "classified_full_fields",
+			err: &oauth2.RetrieveError{
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: "Token expired",
+				ErrorURI:         "https://provider/errors/invalid_grant",
+			},
+			want: want{
+				status:      http.StatusBadGateway,
+				body:        `{"error":"invalid_grant","error_description":"Token expired","error_uri":"https://provider/errors/invalid_grant"}`,
+				contentType: "application/json",
+			},
+		},
+
+		// arbitrary code passes through verbatim (covers the six RFC §5.2
+		// codes plus provider-specific values).
+		{
+			name: "provider_specific_passthrough",
+			err:  &oauth2.RetrieveError{ErrorCode: "bad_refresh_token"},
+			want: want{http.StatusBadGateway, `{"error":"bad_refresh_token"}`, "application/json"},
+		},
+
+		// empty optional fields are omitted (omitempty)
+		{
+			name: "omitempty_description_and_uri",
+			err: &oauth2.RetrieveError{
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: "",
+				ErrorURI:         "",
+			},
+			want: want{http.StatusBadGateway, `{"error":"invalid_grant"}`, "application/json"},
+		},
+
+		// wrapped error is unwrapped via errors.As
+		{
+			name: "wrapped_retrieve_error",
+			err:  fmt.Errorf("token refresh: %w", &oauth2.RetrieveError{ErrorCode: "invalid_grant"}),
+			want: want{http.StatusBadGateway, `{"error":"invalid_grant"}`, "application/json"},
+		},
+
+		// non-RetrieveError (transport-level) → empty body, no Content-Type
+		{
+			name: "transport_error_url_error",
+			err: &url.Error{
+				Op:  "Post",
+				URL: "https://idp/token",
+				Err: errors.New("dial tcp: connection refused"),
+			},
+			want: want{status: http.StatusBadGateway, body: "", contentType: ""},
+		},
+
+		// nil err is defensive (no panic, empty body)
+		{
+			name: "nil_error",
+			err:  nil,
+			want: want{status: http.StatusBadGateway, body: "", contentType: ""},
+		},
+
+		// empty ErrorCode + HTML Body + Response → empty body
+		{
+			name: "empty_code_with_html_body",
+			err: &oauth2.RetrieveError{
+				ErrorCode: "",
+				Body:      []byte("<html>500 Internal Server Error</html>"),
+				Response:  &http.Response{StatusCode: 500},
+			},
+			want: want{status: http.StatusBadGateway, body: "", contentType: ""},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeOAuth2Error(rec, http.StatusBadGateway, c.err)
+
+			assert.Equal(t, c.want.status, rec.Code, "status code")
+			assert.Equal(t, c.want.body, rec.Body.String(), "body")
+			assert.Equal(t, c.want.contentType, rec.Header().Get("Content-Type"), "Content-Type")
+
+			// Cache-prevention headers MUST be on every response (RFC 6749 §5.1).
+			assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"), "Cache-Control")
+			assert.Equal(t, "no-cache", rec.Header().Get("Pragma"), "Pragma")
+		})
+	}
+}

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -216,7 +216,7 @@ func (p *Provider) handleRefresh(w http.ResponseWriter, r *http.Request) {
 			WithError(err).
 			Info("refresh")
 
-		w.WriteHeader(http.StatusBadGateway)
+		writeOAuth2Error(w, http.StatusBadGateway, err)
 		return
 	}
 

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,11 +29,93 @@ func init() {
 
 const rpAuth = "555"
 
+const (
+	markerDeadToken     = "dead-token"
+	markerBadClient     = "bad-client-token"
+	markerUpstream5xx   = "upstream-5xx-token"
+	markerTransportFail = "transport-fail-token"
+)
+
+// doRefresh runs a /refresh request through the tokenizer pipeline against
+// a sealed secret carrying the given marker refresh token. The mock IDP
+// dispatches its failure mode on the marker (see the marker* constants).
+func doRefresh(t *testing.T, marker string, authStyle oauth2.AuthStyle) (*http.Response, *idpRecorder) {
+	_, skz, tkzServer, _, p, idpRec := setupTestServersWithProvider(t, nil, nil, authStyle)
+
+	withRefresh := map[string]string{tokenizer.ParamSubtoken: tokenizer.SubtokenRefresh}
+	refreshClient, err := tokenizer.Client(tkzServer.URL, tokenizer.WithAuth(rpAuth), tokenizer.WithSecret(sealRefreshToken(t, p, marker), withRefresh))
+	assert.NoError(t, err)
+
+	resp, err := refreshClient.Get("http://" + skz.Address + "/idp/refresh")
+	assert.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp, idpRec
+}
+
+func sealRefreshToken(t *testing.T, p *Provider, refreshToken string) string {
+	t.Helper()
+	sealed, err := p.Tokenizer.SealedSecret(&tokenizer.OAuthProcessorConfig{
+		Token: &tokenizer.OAuthToken{RefreshToken: refreshToken},
+	})
+	if err != nil {
+		t.Fatalf("seal refresh token %q: %v", refreshToken, err)
+	}
+	return sealed
+}
+
+// assertRefreshErrorHeaders asserts the wire-shape headers of a /refresh
+// failure response: 502, the given Content-Type (use "" for absent),
+// and the RFC §5.1 cache-prevention pair.
+func assertRefreshErrorHeaders(t *testing.T, resp *http.Response, contentType string) {
+	t.Helper()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	assert.Equal(t, contentType, resp.Header.Get("Content-Type"))
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+	assert.Equal(t, "no-cache", resp.Header.Get("Pragma"))
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	return string(body)
+}
+
+// idpRecorder captures requests received by the mock IDP so tests can
+// assert on the wire shape directly. One per test (no shared state).
+type idpRecorder struct {
+	mu       sync.Mutex
+	requests []*http.Request
+	next     http.Handler
+}
+
+func (r *idpRecorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	_ = req.ParseForm()
+	r.mu.Lock()
+	r.requests = append(r.requests, req)
+	r.mu.Unlock()
+	r.next.ServeHTTP(w, req)
+}
+
+func (r *idpRecorder) all() []*http.Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*http.Request(nil), r.requests...)
+}
+
 func setupTestServers(t *testing.T) (*httptest.Server, *ssokenizer.Server, *httptest.Server, *httptest.Server) {
 	return setupTestServersWithParams(t, nil, nil)
 }
 
 func setupTestServersWithParams(t *testing.T, authParams, tokenParams map[string]string) (*httptest.Server, *ssokenizer.Server, *httptest.Server, *httptest.Server) {
+	rpServer, skz, tkzServer, idpServer, _, _ := setupTestServersWithProvider(t, authParams, tokenParams, oauth2.AuthStyleAutoDetect)
+	return rpServer, skz, tkzServer, idpServer
+}
+
+// setupTestServersWithProvider returns the four servers plus the registered
+// *Provider (for minting sealed secrets) and an idpRecorder (for asserting
+// what the IDP received).
+func setupTestServersWithProvider(t *testing.T, authParams, tokenParams map[string]string, authStyle oauth2.AuthStyle) (*httptest.Server, *ssokenizer.Server, *httptest.Server, *httptest.Server, *Provider, *idpRecorder) {
 	rpServer := httptest.NewServer(rp)
 	t.Cleanup(rpServer.Close)
 	returnURL, err := url.Parse(rpServer.URL)
@@ -40,14 +123,15 @@ func setupTestServersWithParams(t *testing.T, authParams, tokenParams map[string
 	t.Logf("rp=%s", rpServer.URL)
 
 	// Use the parameter-aware mock IDP if custom parameters are provided
-	var idpHandler http.HandlerFunc
+	var idpHandler http.Handler
 	if authParams != nil || tokenParams != nil {
 		idpHandler = createMockIDP(authParams, tokenParams)
 	} else {
 		idpHandler = idp
 	}
 
-	idpServer := httptest.NewServer(idpHandler)
+	idpRec := &idpRecorder{next: idpHandler}
+	idpServer := httptest.NewServer(idpRec)
 	t.Cleanup(idpServer.Close)
 	t.Logf("idp=%s", idpServer.URL)
 
@@ -78,7 +162,7 @@ func setupTestServersWithParams(t *testing.T, authParams, tokenParams map[string
 
 	// we don't know our URL in tests until the server is started, so we can't
 	// populate this earlier.
-	providers["idp"] = &Provider{
+	provider := &Provider{
 		ProviderConfig: ssokenizer.ProviderConfig{
 			Tokenizer: ssokenizer.TokenizerConfig{
 				SealKey: sealKey,
@@ -91,16 +175,18 @@ func setupTestServersWithParams(t *testing.T, authParams, tokenParams map[string
 			ClientID:     testClientID,
 			ClientSecret: testClientSecret,
 			Endpoint: oauth2.Endpoint{
-				AuthURL:  idpServer.URL + "/auth",
-				TokenURL: idpServer.URL + "/token",
+				AuthURL:   idpServer.URL + "/auth",
+				TokenURL:  idpServer.URL + "/token",
+				AuthStyle: authStyle,
 			},
 			Scopes: []string{"my scope"},
 		},
 		AuthRequestParams:  authParams,
 		TokenRequestParams: tokenParams,
 	}
+	providers["idp"] = provider
 
-	return rpServer, skz, tkzServer, idpServer
+	return rpServer, skz, tkzServer, idpServer, provider, idpRec
 }
 
 func checkResponse(t *testing.T, resp *http.Response, expectedPrefix, expectedState string) string {
@@ -180,6 +266,34 @@ func TestOauth2Parallel(t *testing.T) {
 	resp, err := clientB.Get("http://" + skz.Address + "/idp/start?state=second")
 	assert.NoError(t, err)
 	checkResponse(t, resp, rpServer.URL, "second")
+}
+
+func TestRefreshInvalidGrant(t *testing.T) {
+	resp, _ := doRefresh(t, markerDeadToken, oauth2.AuthStyleInHeader)
+
+	assertRefreshErrorHeaders(t, resp, "application/json")
+	assert.Equal(t, `{"error":"invalid_grant","error_description":"Token revoked","error_uri":"https://provider/errors/invalid_grant"}`, readBody(t, resp))
+}
+
+func TestRefreshInvalidClient(t *testing.T) {
+	resp, _ := doRefresh(t, markerBadClient, oauth2.AuthStyleInHeader)
+
+	assertRefreshErrorHeaders(t, resp, "application/json")
+	assert.Equal(t, `{"error":"invalid_client"}`, readBody(t, resp))
+}
+
+func TestRefreshUpstream5xx(t *testing.T) {
+	resp, _ := doRefresh(t, markerUpstream5xx, oauth2.AuthStyleInHeader)
+
+	assertRefreshErrorHeaders(t, resp, "")
+	assert.Equal(t, "", readBody(t, resp), "upstream HTML must not appear in /refresh body")
+}
+
+func TestRefreshTransportError(t *testing.T) {
+	resp, _ := doRefresh(t, markerTransportFail, oauth2.AuthStyleInHeader)
+
+	assertRefreshErrorHeaders(t, resp, "")
+	assert.Equal(t, "", readBody(t, resp))
 }
 
 const (
@@ -362,6 +476,33 @@ var idp = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		if username != testClientID || password != testClientSecret {
 			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		switch r.Form.Get("refresh_token") {
+		case markerDeadToken:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Token revoked","error_uri":"https://provider/errors/invalid_grant"}`))
+			return
+		case markerBadClient:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			return
+		case markerUpstream5xx:
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("<html>503 Service Unavailable</html>"))
+			return
+		case markerTransportFail:
+			// Drop the connection mid-request so the OAuth2 library sees a
+			// transport-level error (no Response object).
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				panic("hijack: " + err.Error())
+			}
+			_ = conn.Close()
 			return
 		}
 


### PR DESCRIPTION
## Summary

- `/refresh` now returns an RFC 6749 §5.2 JSON body when the upstream token exchange fails with a classified OAuth2 error (e.g. `invalid_grant`, `invalid_client`). Previously it returned a bare 502 with an empty body.
- Unclassified failures (transport errors, unparseable upstream responses) still return 502 with an empty body because I wasn't sure what behavior to do here, and decided to maintain the existing (😅)
- & per RFC both`Cache-Control: no-store` and `Pragma: no-cache` headers are set on every error response.

## Why

I was running into issues with providers like GitHub who use exactly-once refresh token rotation. Right now, callers currently get a bare 502 on failure and can't distinguish a revoked token (`invalid_grant`) from a transient upstream error. This lets them decide whether to discard the sealed secret or retry.